### PR TITLE
[#82] Add an Enum constraint for encoders

### DIFF
--- a/enumeratum/core/src/main/scala/kantan/codecs/enumeratum/EnumInstances.scala
+++ b/enumeratum/core/src/main/scala/kantan/codecs/enumeratum/EnumInstances.scala
@@ -44,7 +44,13 @@ trait DecoderInstances {
 /** Defines implicit `Encoder` instances for any enumeratum `Enum` type. */
 trait EncoderInstances {
 
-  implicit def enumeratumEncoder[E, D <: EnumEntry, T](implicit encoder: Encoder[E, String, T]): Encoder[E, D, T] =
+  // We're adding an `Enum` constraint here because:
+  // - it has a major impact for `ValueEnum`
+  // - I haven't been able to decide whether it was useful here or not, but it certainly can't hurt to reduce the
+  //   implicit search space.
+  implicit def enumeratumEncoder[E, D <: EnumEntry: Enum, T](
+    implicit encoder: Encoder[E, String, T]
+  ): Encoder[E, D, T] =
     encoder.contramap(_.entryName)
 
 }


### PR DESCRIPTION
I'm honestly sure whether this helprs or not - tests are inconclusive. But
it certainly can't hurt and will not cause compilation false negatives.

Fixes #82.