### PR TITLE
[#123] Drop Result

### DIFF
--- a/core/shared/src/main/scala/kantan/codecs/Decoder.scala
+++ b/core/shared/src/main/scala/kantan/codecs/Decoder.scala
@@ -196,9 +196,8 @@ object Decoder {
     *
     * The specified function is assumed to throw, and errors will be dealt with properly.
     */
-  def fromUnsafe[E, D, F: IsError, T](f: E ⇒ D): Decoder[E, D, F, T] = Decoder.from { e ⇒
-    IsError.result(f(e))
-  }
+  def fromUnsafe[E, D, F: IsError, T](f: E ⇒ D): Decoder[E, D, F, T] =
+    Decoder.from(e ⇒ IsError[F].safe(f(e)))
 
   implicit def decoderFromExported[E, D, F, T](implicit da: DerivedDecoder[E, D, F, T]): Decoder[E, D, F, T] =
     da.value

--- a/core/shared/src/main/scala/kantan/codecs/error/Error.scala
+++ b/core/shared/src/main/scala/kantan/codecs/error/Error.scala
@@ -41,6 +41,9 @@ abstract class ErrorCompanion[T <: Error](defaultMsg: String)(f: String ⇒ T) e
     override def fromThrowable(cause: Throwable): T = from(Option(cause.getMessage).getOrElse(defaultMsg), cause)
   }
 
+  /** Attempts to evaluate the specified argument, wrapping errors in a `T`. */
+  def safe[A](a: ⇒ A): Either[T, A] = isError.safe(a)
+
   def apply(msg: String, cause: Throwable): T = isError.from(msg, cause)
   def apply(cause: Throwable): T              = isError.fromThrowable(cause)
   def apply(msg: String): T                   = isError.fromMessage(msg)

--- a/core/shared/src/main/scala/kantan/codecs/resource/CloseResult.scala
+++ b/core/shared/src/main/scala/kantan/codecs/resource/CloseResult.scala
@@ -22,9 +22,8 @@ import ResourceError.CloseError
 object CloseResult {
   val success: CloseResult                    = Right(())
   def failure(error: CloseError): CloseResult = Left(error)
-  def apply[U](c: ⇒ U): CloseResult =
-    Result.nonFatal {
-      c
-      ()
-    }.left.map(CloseError.apply)
+  def apply[U](c: ⇒ U): CloseResult = CloseError.safe {
+    c
+    ()
+  }
 }

--- a/core/shared/src/main/scala/kantan/codecs/resource/ResourceIterator.scala
+++ b/core/shared/src/main/scala/kantan/codecs/resource/ResourceIterator.scala
@@ -379,7 +379,7 @@ trait ResourceIterator[+A] extends TraversableOnce[A] with java.io.Closeable { s
     */
   def safe[F](empty: ⇒ F)(f: Throwable ⇒ F): ResourceIterator[Either[F, A]] = new ResourceIterator[Either[F, A]] {
     override def readNext() =
-      if(self.hasNext) Result.nonFatal(self.next()).left.map(f)
+      if(self.hasNext) ResultCompanion.nonFatal(f)(self.next())
       else Left(empty)
     override def checkNext = self.hasNext
     override def release() = self.close()

--- a/docs/src/main/tut/implementation.md
+++ b/docs/src/main/tut/implementation.md
@@ -42,7 +42,7 @@ methods:
 
 ```tut:silent
 object DecodeResult {
-  def apply[A](a: => A): DecodeResult[A] = Result.nonFatal(a).left.map(TypeError.apply)
+  def apply[A](a: => A): DecodeResult[A] = ResultCompanion.nonFatal(TypeError.apply)(a)
   def success[A](a: A): DecodeResult[A] = Right(a)
   def outOfBounds(index: Int): DecodeResult[Nothing] = Left(OutOfBounds(index))
 }


### PR DESCRIPTION
Remove `Result` and the corresponding helpers, replacing them by more convenient methods in `IsError` and `Error`.

Fixes #123.