### PR TITLE
Update dependencies to support Scala.js 1.x (Dropping Scala.js 0.6.x)

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,12 +1,11 @@
 object Versions {
-  private val isScalaJS06  = Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).exists(_.startsWith("0.6"))
   val cats                 = "2.1.1"
   val collectionCompat     = "2.1.6"
   val commonsIo            = "2.6"
   val disciplineScalatest  = "1.0.1"
-  val enumeratum           = if (isScalaJS06) "1.6.0" else "1.6.1"
-  val enumeratumScalacheck = if (isScalaJS06) "1.6.0" else "1.6.1"
-  val imp                  = if (isScalaJS06) "0.4.1" else "0.5.0"
+  val enumeratum           = "1.6.1"
+  val enumeratumScalacheck = "1.6.1"
+  val imp                  = "0.5.0"
   val libra                = "0.7.0"
   val refined              = "0.9.14"
   val scalacheck           = "1.14.3"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,11 +1,12 @@
 object Versions {
+  private val isScalaJS06  = Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).exists(_.startsWith("0.6"))
   val cats                 = "2.1.1"
   val collectionCompat     = "2.1.6"
   val commonsIo            = "2.6"
   val disciplineScalatest  = "1.0.1"
-  val enumeratum           = "1.6.0"
-  val enumeratumScalacheck = "1.6.0"
-  val imp                  = "0.4.1"
+  val enumeratum           = if (isScalaJS06) "1.6.0" else "1.6.1"
+  val enumeratumScalacheck = if (isScalaJS06) "1.6.0" else "1.6.1"
+  val imp                  = if (isScalaJS06) "0.4.1" else "0.5.0"
   val libra                = "0.7.0"
   val refined              = "0.9.14"
   val scalacheck           = "1.14.3"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,5 @@
 addSbtPlugin("com.nrinaudo" % "kantan.sbt-kantan"  % "2.7.1-SNAPSHOT")
 addSbtPlugin("com.nrinaudo" % "kantan.sbt-scalajs" % "2.7.1-SNAPSHOT")
+
+resolvers +=
+  "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,2 @@
-addSbtPlugin("com.nrinaudo" % "kantan.sbt-kantan"  % "2.7.1-SNAPSHOT")
-addSbtPlugin("com.nrinaudo" % "kantan.sbt-scalajs" % "2.7.1-SNAPSHOT")
-
-resolvers +=
-  "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+addSbtPlugin("com.nrinaudo" % "kantan.sbt-kantan"  % "2.7.1")
+addSbtPlugin("com.nrinaudo" % "kantan.sbt-scalajs" % "2.7.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.nrinaudo" % "kantan.sbt-kantan"  % "2.7.0")
-addSbtPlugin("com.nrinaudo" % "kantan.sbt-scalajs" % "2.7.0")
+addSbtPlugin("com.nrinaudo" % "kantan.sbt-kantan"  % "2.7.1-SNAPSHOT")
+addSbtPlugin("com.nrinaudo" % "kantan.sbt-scalajs" % "2.7.1-SNAPSHOT")


### PR DESCRIPTION
Part of nrinaudo/kantan.csv#220

This PR updates some dependencies so they are usable in Scala.js 1.x project.
<del>To support cross building between Scala.js 1.x and 0.6.x, the last versions supporing Scala.js 0.6.x remains (e.g. enumeratum 1.6.0 ).</del>
Scala.js 0.6.x support is dropped (see https://github.com/nrinaudo/kantan.sbt/pull/142#issuecomment-631967726).

You may find which versions supports Scala.js 1.x and 0.6.x from:
https://mvnrepository.com/artifact/org.spire-math/imp
https://mvnrepository.com/artifact/com.beachape/enumeratum
https://mvnrepository.com/artifact/com.beachape/enumeratum-scalacheck