### PR TITLE
avoid deprecated `java.net.URL` constructor

### DIFF
--- a/core/jvm/src/main/scala/kantan/codecs/strings/PlatformSpecificInstances.scala
+++ b/core/jvm/src/main/scala/kantan/codecs/strings/PlatformSpecificInstances.scala
@@ -34,11 +34,13 @@ trait PlatformSpecificInstances {
     * // Decoding example
     * scala> import java.net.URL
     *
+    * scala> import java.net.URI
+    *
     * scala> StringDecoder[URL].decode("http://localhost:8080")
     * res1: StringResult[URL] = Right(http://localhost:8080)
     *
     * // Encoding example
-    * scala> StringEncoder[URL].encode(new URL("http://localhost:8080"))
+    * scala> StringEncoder[URL].encode(new URI("http://localhost:8080").toURL)
     * res2: String = http://localhost:8080
     *   }}}
     */


### PR DESCRIPTION
- https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String)
- https://bugs.openjdk.org/browse/JDK-8295949
- https://github.com/openjdk/jdk/commit/4338f527aa81350e3636dcfbcd2eb17ddaad3914