### PR TITLE
add parentheses. prepare Scala 3

### DIFF
--- a/cats/core/shared/src/test/scala/kantan/codecs/cats/DecodeErrorTests.scala
+++ b/cats/core/shared/src/test/scala/kantan/codecs/cats/DecodeErrorTests.scala
@@ -27,7 +27,7 @@ class DecodeErrorTests extends DisciplineSuite {
   checkAll("DecodeError", EqTests[DecodeError].eqv)
 
   test("Show[DecodeError] should yield a string containing the error message") {
-    forAll { error: DecodeError =>
+    forAll { (error: DecodeError) =>
       Show[DecodeError].show(error) should include(error.message)
     }
   }

--- a/core/jvm/src/test/scala/kantan/codecs/resource/bom/BomReaderTests.scala
+++ b/core/jvm/src/test/scala/kantan/codecs/resource/bom/BomReaderTests.scala
@@ -39,38 +39,38 @@ class BomReaderTests extends AnyFunSuite with ScalaCheckPropertyChecks with Matc
   }
 
   test("UTF-8 BOMs should be read properly") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       read(str, Codec.UTF8) should be(str)
     }
   }
 
   test("UTF-16LE BOMs should be read properly") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       read(str, Codec(Charset.forName("UTF-16LE"))) should be(str)
     }
   }
 
   test("UTF-16BE BOMs should be read properly") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       read(str, Codec(Charset.forName("UTF-16BE"))) should be(str)
     }
   }
 
   test("UTF-32LE BOMs should be read properly") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       read(str, Codec(Charset.forName("UTF-32LE"))) should be(str)
     }
   }
 
   test("UTF-32BE BOMs should be read properly") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       read(str, Codec(Charset.forName("UTF-32BE"))) should be(str)
     }
   }
 
   // Uses Gen.identifier to make sure we only get strings that are actually encodable in ISO-8859-1.
   test("Non-BOM encodings should be read properly") {
-    forAll(Gen.identifier) { str: String =>
+    forAll(Gen.identifier) { (str: String) =>
       read(str, Codec.ISO8859) should be(str)
     }
   }

--- a/core/jvm/src/test/scala/kantan/codecs/resource/bom/BomWriterTests.scala
+++ b/core/jvm/src/test/scala/kantan/codecs/resource/bom/BomWriterTests.scala
@@ -43,31 +43,31 @@ class BomWriterTests extends AnyFunSuite with ScalaCheckPropertyChecks with Matc
       .getBOM()
 
   test("UTF-8 BOMs should be written properly") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       write(str, Codec.UTF8) should be(BOM.UTF_8)
     }
   }
 
   test("UTF-16LE BOMs should be written properly") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       write(str, Codec(Charset.forName("UTF-16LE"))) should be(BOM.UTF_16LE)
     }
   }
 
   test("UTF-16BE BOMs should be written properly") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       write(str, Codec(Charset.forName("UTF-16BE"))) should be(BOM.UTF_16BE)
     }
   }
 
   test("UTF-32LE BOMs should be written properly") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       write(str, Codec(Charset.forName("UTF-32LE"))) should be(BOM.UTF_32LE)
     }
   }
 
   test("UTF-32BE BOMs should be written properly") {
-    forAll { str: String =>
+    forAll { (str: String) =>
       write(str, Codec(Charset.forName("UTF-32BE"))) should be(BOM.UTF_32BE)
     }
   }

--- a/core/shared/src/test/scala/kantan/codecs/resource/ResourceIteratorTests.scala
+++ b/core/shared/src/test/scala/kantan/codecs/resource/ResourceIteratorTests.scala
@@ -284,7 +284,7 @@ class ResourceIteratorTests
   }
 
   test("a safe iterator should wrap errors in next") {
-    forAll { is: FailingIterator[Int] =>
+    forAll { (is: FailingIterator[Int]) =>
       var closed = false
 
       val res = is.resourceIterator
@@ -298,7 +298,7 @@ class ResourceIteratorTests
   }
 
   test("A closed iterator should not have next elements") {
-    forAll { is: List[Int] =>
+    forAll { (is: List[Int]) =>
       val res = ResourceIterator(is: _*)
       res.close()
       res.hasNext should be(false)

--- a/java8/core/src/test/scala/kantan/codecs/strings/java8/FormatTests.scala
+++ b/java8/core/src/test/scala/kantan/codecs/strings/java8/FormatTests.scala
@@ -42,7 +42,7 @@ class FormatTests extends DisciplineSuite {
     val format    = Format.from(formatStr).getOrElse(sys.error(s"Not a valid format: '$formatStr"))
     val formatter = DateTimeFormatter.ofPattern(formatStr)
 
-    forAll { d: LocalDateTime =>
+    forAll { (d: LocalDateTime) =>
       val str: String = formatter.format(d)
 
       format.parseLocalDateTime(str) should be(Right(LocalDateTime.parse(str, formatter)))
@@ -57,7 +57,7 @@ class FormatTests extends DisciplineSuite {
     val format    = Format.from(formatStr).getOrElse(sys.error(s"Not a valid format: '$formatStr"))
     val formatter = DateTimeFormatter.ofPattern(formatStr)
 
-    forAll { d: ZonedDateTime =>
+    forAll { (d: ZonedDateTime) =>
       val str: String = formatter.format(d)
 
       format.parseZonedDateTime(str) should be(Right(ZonedDateTime.parse(str, formatter)))
@@ -71,7 +71,7 @@ class FormatTests extends DisciplineSuite {
     val format    = Format.from(formatStr).getOrElse(sys.error(s"Not a valid format: '$formatStr"))
     val formatter = DateTimeFormatter.ofPattern(formatStr)
 
-    forAll { d: LocalTime =>
+    forAll { (d: LocalTime) =>
       val str: String = formatter.format(d)
 
       format.parseLocalTime(str) should be(Right(LocalTime.parse(str, formatter)))
@@ -86,7 +86,7 @@ class FormatTests extends DisciplineSuite {
     val format    = Format.from(formatStr).getOrElse(sys.error(s"Not a valid format: '$formatStr"))
     val formatter = DateTimeFormatter.ofPattern(formatStr)
 
-    forAll { d: LocalDate =>
+    forAll { (d: LocalDate) =>
       val str: String = formatter.format(d)
 
       format.parseLocalDate(str) should be(Right(LocalDate.parse(str, formatter)))
@@ -100,7 +100,7 @@ class FormatTests extends DisciplineSuite {
     val format    = Format.from(formatStr).getOrElse(sys.error(s"Not a valid format: '$formatStr"))
     val formatter = DateTimeFormatter.ofPattern(formatStr)
 
-    forAll { d: ZonedDateTime =>
+    forAll { (d: ZonedDateTime) =>
       val str: String = formatter.format(d)
 
       format.parseZonedDateTime(str) should be(Right(ZonedDateTime.parse(str, formatter)))

--- a/laws/shared/src/test/scala/kantan/codecs/laws/CodecValueTests.scala
+++ b/laws/shared/src/test/scala/kantan/codecs/laws/CodecValueTests.scala
@@ -53,13 +53,13 @@ class CodecValueTests extends AnyFunSuite with ScalaCheckPropertyChecks with Mat
     f: E => D
   )(implicit arbL: Arbitrary[LegalValue[E, D, T]], arbI: Arbitrary[IllegalValue[E, D, T]]): Unit = {
     test(s"Arbitrary[LegalValue[$e, $d]] should generate legal values") {
-      forAll { li: LegalValue[E, D, T] =>
+      forAll { (li: LegalValue[E, D, T]) =>
         f(li.encoded) should be(li.decoded)
       }
     }
 
     test(s"Arbitrary[IllegalValue[$e, $d]] should generate illegal values") {
-      forAll { li: IllegalValue[E, D, T] =>
+      forAll { (li: IllegalValue[E, D, T]) =>
         Prop.throws(classOf[Exception])(f(li.encoded))
         ()
       }

--- a/scalaz/core/shared/src/test/scala/kantan/codecs/scalaz/DecodeErrorTests.scala
+++ b/scalaz/core/shared/src/test/scala/kantan/codecs/scalaz/DecodeErrorTests.scala
@@ -27,7 +27,7 @@ class DecodeErrorTests extends ScalazDisciplineSuite {
   checkAll("DecodeError", equ.laws[DecodeError])
 
   test("Show[DecodeError] should yield a string containing the error message") {
-    forAll { error: DecodeError =>
+    forAll { (error: DecodeError) =>
       Show[DecodeError].shows(error) should include(error.message)
     }
   }


### PR DESCRIPTION
Scala 3 require parentheses

```
Welcome to Scala 3.3.5 (21.0.6, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> def f: Int => Int = { a: Int => a }
-- Error: ----------------------------------------------------------------------
1 |def f: Int => Int = { a: Int => a }
  |                             ^
  |                 parentheses are required around the parameter of a lambda
                                                                                                                                             
scala> def f: Int => Int = { (a: Int) => a }
def f: Int => Int
                                                                                                                                             
scala> def f: Int => Int = { a => a }
def f: Int => Int
```