### PR TITLE
deprecate LabelledGeneric instances

### DIFF
--- a/shapeless/core/shared/src/main/scala/kantan/codecs/shapeless/ShapelessInstances.scala
+++ b/shapeless/core/shared/src/main/scala/kantan/codecs/shapeless/ShapelessInstances.scala
@@ -55,7 +55,8 @@ trait ShapelessInstances {
     DerivedEncoder.from(s => er.value.encode(gen.to(s)))
 
   /** Similar to [[caseClassEncoder]], but working with `LabelledGeneric` rather than just `Generic`. */
-  implicit def caseClassEncoderFromLabelled[E, D, T, H <: HList](implicit
+  @deprecated("will be removed")
+  def caseClassEncoderFromLabelled[E, D, T, H <: HList](implicit
     generic: LabelledGeneric.Aux[D, H],
     hEncoder: Lazy[Encoder[E, H, T]]
   ): DerivedEncoder[E, D, T] =
@@ -73,7 +74,8 @@ trait ShapelessInstances {
     DerivedDecoder.from(s => dr.value.decode(s).map(gen.from))
 
   /** Similar to [[caseClassDecoder]], but working with `LabelledGeneric` rather than just `Generic`. */
-  implicit def caseClassDecoderFromLabelled[E, D, F, T, H <: HList](implicit
+  @deprecated("will be removed")
+  def caseClassDecoderFromLabelled[E, D, F, T, H <: HList](implicit
     generic: LabelledGeneric.Aux[D, H],
     hDecoder: Lazy[Decoder[E, H, F, T]]
   ): DerivedDecoder[E, D, F, T] =


### PR DESCRIPTION
because `LabelledGeneric` is too slow. see benchmark result

- https://github.com/xuwei-k/kantan-csv-compile-time-benchmark/compare/7d4a42b5376f95f83bd26c058535d42aeddbd7cc...0f0d68b641b3c51ee568e8ea5afc3cd454836587
- https://github.com/xuwei-k/kantan-csv-compile-time-benchmark/commit/a12c128809fb69b5d777ff3fdb6db11560aca51c

|                                      | median | average | 
| ------------------------------------ | ------ | ------- | 
| custom implementation                | 10     | 10.3    | 
| wildcard import                      | 110    | 109.4   | 
| explicit import with LabelledGeneric | 93     | 92.8    | 
| explicit import                      | 19     | 19.2    | 